### PR TITLE
Seems to be redundant the multiple catch use

### DIFF
--- a/src/pyflame.cc
+++ b/src/pyflame.cc
@@ -166,9 +166,6 @@ int main(int argc, char **argv) {
         std::cout << "(idle)\n";
       }
     }
-  } catch (const FatalException &exc) {
-    std::cerr << exc.what() << std::endl;
-    return 1;
   } catch (const std::exception &exc) {
     std::cerr << exc.what() << std::endl;
     return 1;


### PR DESCRIPTION
- The first catch was for FatalException, which is a subclass of std::runtime_error
- The second catch was for std::exception, std::runtime_error is a subclass of std::exception
- Both have the same body

Hence there's no need for the multiple catch case.