### PR TITLE
teach runtests.sh how to run all of the pythons

### DIFF
--- a/runtests.sh
+++ b/runtests.sh
@@ -4,17 +4,46 @@ set -ex
 
 ENVDIR="./test_env"
 
-if [ $# -eq 1 ]; then
-    PYTHONVERSION=$1
-elif [ -z "$PYTHONVERSION" ]; then
-    PYTHONVERSION=python2
+# Run tests using pip; $1 = python version
+run_pip_tests() {
+    virtualenv -p "$1" "${ENVDIR}"
+    trap "rm -rf ${ENVDIR}" EXIT
+
+    . "${ENVDIR}/bin/activate"
+    pip install --upgrade pip
+    pip install pytest
+    py.test tests/
+
+    # clean up the trap
+    rm -rf "${ENVDIR}" EXIT
+    trap "" EXIT
+}
+
+# See if we can run the pip tests with this Python version
+try_pip_tests() {
+    if which "$1" &>/dev/null; then
+        run_pip_tests "$1"
+    fi
+}
+
+# This runs the tests for building an RPM
+run_fedora_tests() {
+    py.test-2 tests/
+    py.test-3 tests/
+}
+
+if [ "$1" = "fedora" ]; then
+    # If the first arg is fedora, don't use Pip
+    run_fedora_tests
+elif [ $# -eq 1 ]; then
+    # Run the tests for a particular version of python
+    run_pip_tests "$1"
+elif [ -n "$PYTHONVERSION" ]; then
+    # Run the tests for $PYTHONVERSION
+    run_pip_tests "$PYTHONVERSION"
+else
+    # Try various places where we might find Python
+    for py in python{,2,3}; do
+        try_pip_tests "$py"
+    done
 fi
-
-trap "rm -rf ${ENVDIR}" EXIT
-
-virtualenv -p "$PYTHONVERSION" "${ENVDIR}"
-. "${ENVDIR}/bin/activate"
-pip install --upgrade pip
-pip install pytest
-py.test tests/
-exit $?


### PR DESCRIPTION
A few changes to `runtests.sh`:
 * The file is now executable, so it can be run as `./runtests.sh`
 * When invoked without any arguments it will try to find different places where Python might be installed
 * When invoked with the argument `fedora` it will run the tests in a manner suitable for the Fedora RPM package, i.e. under both Python 2/3 and without using pip; see [RH 1388294](https://bugzilla.redhat.com/show_bug.cgi?id=1388294)