### PR TITLE
Add libtool as a dependency for Ubuntu instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The following command should install the necessary packages to build on Debian
 
 ```bash
 # Install build dependencies on Debian or Ubuntu.
-sudo apt-get install autoconf automake autotools-dev g++ pkg-config python-dev
+sudo apt-get install autoconf automake autotools-dev g++ pkg-config python-dev libtool
 ```
 
 If you'd like to build a Debian package there's already a `debian/` directory at


### PR DESCRIPTION
I found that on my Ubuntu distribution, I needed to run `sudo apt-get libtool` in addition to these instructions in order to get `./autogen.sh` to work.

My distribution was `Welcome to Ubuntu 12.04.5 LTS (GNU/Linux 3.2.0-79-virtual x86_64)`