### PR TITLE
Fix issue #62

### DIFF
--- a/src/ptrace.cc
+++ b/src/ptrace.cc
@@ -287,9 +287,7 @@ void PtraceCleanup(pid_t pid) {
   probe_ = 0;
 }
 #else
-void PtraceCleanup(pid_t pid) {
-  PtraceDetach(pid);
-}
+void PtraceCleanup(pid_t pid) { PtraceDetach(pid); }
 #endif
 
 }  // namespace pyflame

--- a/src/pyfrob.cc
+++ b/src/pyfrob.cc
@@ -24,7 +24,9 @@
 #include "./ptrace.h"
 #include "./symbol.h"
 
-#define FROB_FUNCS std::vector<Thread> GetThreads(pid_t pid, PyAddresses addr);
+#define FROB_FUNCS                                            \
+  std::vector<Thread> GetThreads(pid_t pid, PyAddresses addr, \
+                                 bool enable_threads);
 
 namespace pyflame {
 namespace {
@@ -159,5 +161,7 @@ void PyFrob::DetectPython() {
   SetPython(version);
 }
 
-std::vector<Thread> PyFrob::GetThreads() { return get_threads_(pid_, addrs_); }
+std::vector<Thread> PyFrob::GetThreads() {
+  return get_threads_(pid_, addrs_, enable_threads_);
+}
 }  // namespace pyflame

--- a/src/pyfrob.h
+++ b/src/pyfrob.h
@@ -23,7 +23,7 @@ namespace pyflame {
 
 // Get the threads. Each thread stack will be in reverse order (most recent
 // frame first).
-typedef std::vector<Thread> (*get_threads_t)(pid_t, PyAddresses);
+typedef std::vector<Thread> (*get_threads_t)(pid_t, PyAddresses, bool);
 
 // Frobber to get python stack stuff; this encapsulates all of the Python
 // interpreter logic.

--- a/tests/threaded_busy.py
+++ b/tests/threaded_busy.py
@@ -1,0 +1,34 @@
+# Copyright 2016 Uber Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+import threading
+
+
+def do_sleep():
+    while True:
+        pass
+
+
+def main():
+    sys.stdout.write('%d\n' % (os.getpid(),))
+    sys.stdout.flush()
+    thread = threading.Thread(target=do_sleep)
+    thread.start()
+    do_sleep()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
If the user has not passed in the `--threads` option, we should not attempt to walk the thread list, even if it is available.

I've also tweaked the documentation, and merged the sections on idle time and threading, since these two are more intimately linked now.