### PR TITLE
Fix line number parsing for Python 3

### DIFF
--- a/src/frob.cc
+++ b/src/frob.cc
@@ -53,6 +53,11 @@ unsigned long StringSize(unsigned long addr) {
 unsigned long StringData(unsigned long addr) {
   return addr + offsetof(PyStringObject, ob_sval);
 }
+
+unsigned long ByteData(unsigned long addr) {
+  return addr + offsetof(PyStringObject, ob_sval);
+}
+
 #elif PYFLAME_PY_VERSION == 3
 namespace py3 {
 unsigned long StringSize(unsigned long addr) {
@@ -63,6 +68,11 @@ unsigned long StringData(unsigned long addr) {
   // this works only if the filename is all ascii *fingers crossed*
   return addr + sizeof(PyASCIIObject);
 }
+
+unsigned long ByteData(unsigned long addr) {
+  return addr + offsetof(PyBytesObject, ob_sval);
+}
+
 #else
 static_assert(false, "uh oh, bad PYFLAME_PY_VERSION");
 #endif
@@ -92,7 +102,7 @@ size_t GetLine(pid_t pid, unsigned long frame, unsigned long f_code) {
   int line = PtracePeek(pid, f_code + offsetof(PyCodeObject, co_firstlineno)) &
              std::numeric_limits<int>::max();
   const std::unique_ptr<uint8_t[]> tbl =
-      PtracePeekBytes(pid, StringData(co_lnotab), size);
+      PtracePeekBytes(pid, ByteData(co_lnotab), size);
   size /= 2;  // since we increment twice in each loop iteration
   const uint8_t *p = tbl.get();
   int addr = 0;


### PR DESCRIPTION
For Python 3 co_lnotab was erroneously interpreted as an unicode object,
where it actually is a bytes object.