### PR TITLE
Refactor how the test suite is invoked.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ script:
   - ./autogen.sh
   - ./configure
   - make
-  - make test
+  - ./runtests.sh travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ script:
   - ./autogen.sh
   - ./configure
   - make
-  - ./runtests.sh travis
+  - ./runtests.sh python

--- a/Makefile.am
+++ b/Makefile.am
@@ -4,8 +4,10 @@ ACLOCAL_AMFLAGS = -I m4
 
 man1_MANS = pyflame.man
 
+.PHONY: clean-local
 clean-local:
 	rm -f core.* pyflame
 
+.PHONY: test
 test:
-	bash runtests.sh
+	./runtests.sh

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,29 +1,30 @@
 #!/bin/bash
 
-set -ex
+set -e
 
 ENVDIR="./test_env"
 
 # Run tests using pip; $1 = python version
 run_pip_tests() {
-  virtualenv -p "$1" "${ENVDIR}"
+  virtualenv -q -p "$1" "${ENVDIR}"
   trap 'rm -rf ${ENVDIR}' EXIT
 
   . "${ENVDIR}/bin/activate"
-  pip install --upgrade pip
-  pip install pytest
+  pip install -q pytest
 
   find tests/ -name '*.pyc' -delete
-  py.test tests/
+  py.test -q tests/
 
   # clean up the trap
   rm -rf "${ENVDIR}" EXIT
   trap "" EXIT
 }
 
-# See if we can run the pip tests with this Python version
+# Make a best effort to run the tests against some Python version.
 try_pip_tests() {
-  if which "$1" &>/dev/null; then
+  if command -v "$1" &>/dev/null; then
+    echo -n "Running test suite against "
+    "$1" --version
     run_pip_tests "$1"
   fi
 }

--- a/runtests.sh
+++ b/runtests.sh
@@ -4,11 +4,6 @@ set -ex
 
 ENVDIR="./test_env"
 
-# Used for Travis.
-pyversion() {
-  python -c 'import sys; print("python%d" % sys.version_info.major)'
-}
-
 # Run tests using pip; $1 = python version
 run_pip_tests() {
   virtualenv -p "$1" "${ENVDIR}"
@@ -42,8 +37,6 @@ run_rpm_tests() {
 if [ $# -eq 0 ]; then
   try_pip_tests python
   try_pip_tests python3
-elif [ "$1" = "travis" ]; then
-  run_pip_tests "$(pyversion)"
 elif [ "$1" = "rpm" ]; then
   run_rpm_tests
 else

--- a/runtests.sh
+++ b/runtests.sh
@@ -3,21 +3,18 @@
 set -e
 
 ENVDIR="./test_env"
+trap 'rm -rf ${ENVDIR}' EXIT
 
 # Run tests using pip; $1 = python version
 run_pip_tests() {
+  rm -rf "${ENVDIR}"
   virtualenv -q -p "$1" "${ENVDIR}"
-  trap 'rm -rf ${ENVDIR}' EXIT
 
   . "${ENVDIR}/bin/activate"
   pip install -q pytest
 
   find tests/ -name '*.pyc' -delete
   py.test -q tests/
-
-  # clean up the trap
-  rm -rf "${ENVDIR}" EXIT
-  trap "" EXIT
 }
 
 # Make a best effort to run the tests against some Python version.


### PR DESCRIPTION
This changes the test suite so that `make test` will try to run both Python 2 and Python 3 tests by default, and updates the Travis config accordingly.