### PR TITLE
Build Pyflame on i386 hosts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,65 @@
 sudo: required
 compiler: gcc
 dist: trusty
-language: python
+language: cpp
 
-python:
-  - "2.6"
-  - "2.7"
-  - "3.4"
-  - "3.5"
-  - "3.6"
+# This is kind of hacky, so it deserves an explanation.
+#
+# We want to test all supported Python builds against both 32-bit and 64-bit
+# builds. The Travis build matrix for old Python versions is completely busted,
+# there are missing files, and they do gross stuff to the environment, like
+# trying to install everything into virtualenvs. Therefore, we need to install
+# the Python releases maintained in ppa:fkrull/deadsnakes.
+#
+# The i386 Python 2.x releases from ppa:fkrull/deadsnakes put their .pc files
+# in the wrong place. For some reason forcing PKG_CONFIG_PATH doesn't help, so
+# we manually export the flags. Pull requests welcome, if anyone figure out a
+# less bad way to do this.
+#
+# The tests don't work for the i386 builds at all, because Travis only lets you
+# run things on amd64 hosts. There are a couple of other projects using Travis
+# that are using qemu to run i386 tests, but that sounds really slow and
+# complicated. Again, pull requests welcome if anyone figures out how to test
+# the i386 builds.
+env:
+  global:
+    - MAKEOPTS=-j3
+  matrix:
+    - ARCH=i386 PYVERSION=python2.6 PY26_CFLAGS=-I/usr/include/python2.6 PY26_LIBS=-lpython2.6
+    - ARCH=i386 PYVERSION=python2.7 PY26_CFLAGS=-I/usr/include/python2.7 PY26_LIBS=-lpython2.7
+    - ARCH=i386 PYVERSION=python3.4
+    - ARCH=i386 PYVERSION=python3.5
+    - ARCH=i386 PYVERSION=python3.6
+    - ARCH=amd64 PYVERSION=python2.6
+    - ARCH=amd64 PYVERSION=python2.7
+    - ARCH=amd64 PYVERSION=python3.4
+    - ARCH=amd64 PYVERSION=python3.5
+    - ARCH=amd64 PYVERSION=python3.6
 
 addons:
   apt:
     sources:
-      # Needed only because the Travis VMs don't have python-3.6.pc
-      - sourceline: 'ppa:jonathonf/python-3.6'
+      - sourceline: 'ppa:fkrull/deadsnakes'
     packages:
       - autotools-dev
-      - g++
       - pkg-config
-      - python-dev
-      - python3-dev
-      - python3.6-dev
+
+install:
+  - travis_retry sudo dpkg --add-architecture "$ARCH"
+  - travis_retry sudo apt-get update
+  - travis_retry sudo apt-get install "${PYVERSION}"{,-minimal,-dev}:"${ARCH}"
+  - |
+    if [ "$ARCH" == "i386" ]; then
+      sudo apt-get install g++{,-multilib} pkg-config:"${ARCH}"
+      export CFLAGS=-m32
+      export CXXFLAGS=-m32
+      export CONFIGUREOPTS="--host=i686-pc-linux-gnu"
+    fi
 
 script:
   - sudo sysctl kernel.yama.ptrace_scope=0
   - ./autogen.sh
-  - ./configure
-  - make
-  - ./runtests.sh python
+  - ./configure $CONFIGUREOPTS
+  - make $MAKEOPTS
+  - file ./src/pyflame
+  - if [ "$ARCH" == "amd64" ]; then ./runtests.sh "$PYVERSION"; fi

--- a/configure.ac
+++ b/configure.ac
@@ -4,12 +4,14 @@ AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_HEADERS([src/config.h])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_SRCDIR([src/pyflame.cc])
-AC_CANONICAL_TARGET
 
-# Fail early if the user tries to build on BSD/OS X
-AS_IF([test x"$target_os" = xlinux-gnu], [], [AC_MSG_ERROR([Pyflame can only be built for Linux hosts])])
+# Fail early if the user tries to build for BSD/OS X
+AC_CANONICAL_HOST
+AS_CASE([$host_os],
+        [linux-gnu*], [],
+        [AC_MSG_ERROR([Pyflame can only be built for Linux hosts])])
 
-AS_IF([test x"$target_cpu" = xx86_64],
+AS_IF([test x"$host_cpu" = xx86_64],
       [AC_MSG_NOTICE([x86-64 system, threads will be supported])
        AC_DEFINE([ENABLE_THREADS], [1], [Threads are enabled.])
       ],
@@ -68,7 +70,7 @@ AC_FUNC_MMAP
 AC_CHECK_FUNCS([getpagesize memmove munmap strerror strtol strtoul])
 
 AC_DEFINE_UNQUOTED(PYFLAME_VERSION_STR,
-["Pyflame $PACKAGE_VERSION (commit `cd $srcdir && git describe --always`) $target_os $target_cpu"],
+["Pyflame $PACKAGE_VERSION (commit `cd $srcdir && git describe --always`) $host_os $host_cpu"],
 [A string containing build information.])
 
 PKG_CHECK_MODULES([PY26], [python2], [enable_py26="yes"], [AC_MSG_WARN([Building without Python 2.6/2.7 support])])

--- a/src/ptrace.cc
+++ b/src/ptrace.cc
@@ -97,6 +97,11 @@ void PtraceDetach(pid_t pid) {
   }
 }
 
+// Like PtraceDetach(), but ignore errors.
+static inline void SafeDetach(pid_t pid) noexcept {
+  ptrace(PTRACE_DETACH, pid, 0, 0);
+}
+
 void PtraceInterrupt(pid_t pid) {
   if (ptrace(PTRACE_INTERRUPT, pid, 0, 0)) {
     throw PtraceException("Failed to PTRACE_INTERRUPT");
@@ -289,11 +294,6 @@ long PtraceCallFunction(pid_t pid, unsigned long addr) {
   PtraceSetRegs(pid, oldregs);
   return newregs.rax;
 };
-
-// Like PtraceDetach(), but ignore errors.
-static inline void SafeDetach(pid_t pid) noexcept {
-  ptrace(PTRACE_DETACH, pid, 0, 0);
-}
 
 void PtraceCleanup(pid_t pid) noexcept {
   // Clean up the memory area allocated by AllocPage().


### PR DESCRIPTION
As noted in the comments, this is really hacky. Still need to figure out how to test the i386 builds. It also wouldn't hurt to build/test against 32-bit and 64-bit ARM builds....