### PR TITLE
Get the Pyflame test suite to pass on i386

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,8 @@ install:
   - travis_retry sudo dpkg --add-architecture "$ARCH"
   - travis_retry sudo apt-get update
   - travis_retry sudo apt-get install "${PYVERSION}"{,-minimal,-dev}:"${ARCH}"
+  - dpkg -L "${PYVERSION}:${ARCH}"
+  - dpkg -L "${PYVERSION}-minimal:${ARCH}"
   - |
     if [ "$ARCH" == "i386" ]; then
       sudo apt-get install g++{,-multilib} pkg-config:"${ARCH}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,4 +65,4 @@ script:
   - ./configure $CONFIGUREOPTS
   - make $MAKEOPTS
   - file ./src/pyflame
-  - ./runtests.sh "$PYVERSION"
+  - ./runtests.sh -x "$PYVERSION"

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ addons:
       - pkg-config
 
 install:
+  - sudo sysctl kernel.yama.ptrace_scope=0
   - travis_retry sudo dpkg --add-architecture "$ARCH"
   - travis_retry sudo apt-get update
   - travis_retry sudo apt-get install "${PYVERSION}"{,-minimal,-dev}:"${ARCH}"
@@ -57,9 +58,8 @@ install:
     fi
 
 script:
-  - sudo sysctl kernel.yama.ptrace_scope=0
   - ./autogen.sh
   - ./configure $CONFIGUREOPTS
   - make $MAKEOPTS
   - file ./src/pyflame
-  - if [ "$ARCH" == "amd64" ]; then ./runtests.sh "$PYVERSION"; fi
+  - ./runtests.sh "$PYVERSION"

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,7 @@ install:
   - travis_retry sudo dpkg --add-architecture "$ARCH"
   - travis_retry sudo apt-get update
   - travis_retry sudo apt-get install "${PYVERSION}"{,-minimal,-dev}:"${ARCH}"
+  - env
   - dpkg -L "${PYVERSION}:${ARCH}"
   - dpkg -L "${PYVERSION}-minimal:${ARCH}"
   - |

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.68])
-AC_INIT([pyflame], [1.5.3], [evan@eklitzke.org])
+AC_INIT([pyflame], [1.5.4], [evan@eklitzke.org])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_HEADERS([src/config.h])
 AC_CONFIG_MACRO_DIR([m4])
@@ -14,10 +14,14 @@ AS_CASE([$host_os],
 AS_IF([test x"$host_cpu" = xx86_64],
       [AC_MSG_NOTICE([x86-64 system, threads will be supported])
        AC_DEFINE([ENABLE_THREADS], [1], [Threads are enabled.])
+       AC_DEFINE([USE_ELF64], [1], [Expect 64-bit ELF symbols.])
       ],
       [AC_MSG_NOTICE([Threading support will be disabled (only works on x86-64)])
        AC_DEFINE([ENABLE_THREADS], [0], [Threads are enabled.])
+       AC_DEFINE([USE_ELF64], [0], [Expect 64-bit ELF symbols.])
       ])
+
+AC_DEFINE_UNQUOTED([HOST_CPU], ["$host_cpu"], [CPU of target architecture.])
 
 AM_INIT_AUTOMAKE([dist-bzip2 foreign subdir-objects -Wall -Werror])
 
@@ -69,9 +73,10 @@ AC_FUNC_LSTAT_FOLLOWS_SLASHED_SYMLINK
 AC_FUNC_MMAP
 AC_CHECK_FUNCS([getpagesize memmove munmap strerror strtol strtoul])
 
-AC_DEFINE_UNQUOTED(PYFLAME_VERSION_STR,
-["Pyflame $PACKAGE_VERSION (commit `cd $srcdir && git describe --always`) $host_os $host_cpu"],
-[A string containing build information.])
+AC_DEFINE_UNQUOTED(
+  [PYFLAME_VERSION_STR],
+  ["Pyflame $PACKAGE_VERSION (commit `cd $srcdir && git describe --always`) $host_os $host_cpu"],
+  [A string containing build information.])
 
 PKG_CHECK_MODULES([PY26], [python2], [enable_py26="yes"], [AC_MSG_WARN([Building without Python 2.6/2.7 support])])
 AM_CONDITIONAL([ENABLE_PY26], [test x"$enable_py26" = xyes])

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+pyflame (1.5.4) unstable; urgency=medium
+
+  * More fixes for 32-bit Pyflame builds.
+
+ -- Evan Klitzke <evan@death.star>  Tue, 08 Aug 2017 00:16:42 -0700
+
 pyflame (1.5.3) unstable; urgency=medium
 
   * Fix 32-bit builds.

--- a/src/prober.cc
+++ b/src/prober.cc
@@ -68,6 +68,14 @@ static inline std::chrono::microseconds ToMicroseconds(double val) {
   return std::chrono::microseconds{static_cast<long>(val * 1000000)};
 }
 
+static inline bool EndsWith(std::string const &value,
+                            std::string const &ending) {
+  if (ending.size() > value.size()) {
+    return false;
+  }
+  return std::equal(ending.rbegin(), ending.rend(), value.rbegin());
+}
+
 namespace pyflame {
 
 typedef std::unordered_map<frames_t, size_t, FrameHash> buckets_t;
@@ -247,7 +255,7 @@ finish_arg_parse:
 
 int Prober::InitiatePtrace(char **argv) {
   if (trace_) {
-    if (trace_target_.find("pyflame") != std::string::npos) {
+    if (EndsWith(trace_target_, "/pyflame")) {
       std::cerr << "You tried to pyflame a pyflame, naughty!\n";
       return 1;
     }

--- a/src/symbol.cc
+++ b/src/symbol.cc
@@ -24,7 +24,6 @@
 #include <iostream>
 #include <sstream>
 
-#include "./config.h"
 #include "./posix.h"
 
 namespace pyflame {
@@ -69,9 +68,8 @@ void ELF::Open(const std::string &target, Namespace *ns) {
   int elf_class = hdr()->e_ident[EI_CLASS];
   if (elf_class != ARCH_ELFCLASS) {
     std::ostringstream ss;
-    ss << "Target ELF file has EI_CLASS = " << elf_class
-       << " but for this architecture we expected to see class "
-       << ARCH_ELFCLASS << " (HOST_CPU = " HOST_CPU ")";
+    ss << "Target ELF file has EI_CLASS=" << elf_class
+       << ", but for this architecture we expected EI_CLASS=" << ARCH_ELFCLASS;
     throw FatalException(ss.str());
   }
 }

--- a/src/symbol.cc
+++ b/src/symbol.cc
@@ -24,6 +24,7 @@
 #include <iostream>
 #include <sstream>
 
+#include "./config.h"
 #include "./posix.h"
 
 namespace pyflame {
@@ -65,8 +66,13 @@ void ELF::Open(const std::string &target, Namespace *ns) {
     ss << "File " << target << " does not have correct ELF magic header";
     throw FatalException(ss.str());
   }
-  if (hdr()->e_ident[EI_CLASS] != ARCH_ELFCLASS) {
-    throw FatalException("ELF class does not match host architecture");
+  int elf_class = hdr()->e_ident[EI_CLASS];
+  if (elf_class != ARCH_ELFCLASS) {
+    std::ostringstream ss;
+    ss << "Target ELF file has EI_CLASS = " << elf_class
+       << " but for this architecture we expected to see class "
+       << ARCH_ELFCLASS << " (HOST_CPU = " HOST_CPU ")";
+    throw FatalException(ss.str());
   }
 }
 

--- a/src/symbol.h
+++ b/src/symbol.h
@@ -22,23 +22,22 @@
 #include <string>
 #include <vector>
 
+#include "./config.h"
 #include "./exc.h"
 #include "./namespace.h"
 
-#if (__WORDSIZE == 64)
+#if USE_ELF64
 #define ehdr_t Elf64_Ehdr
 #define shdr_t Elf64_Shdr
 #define dyn_t Elf64_Dyn
 #define sym_t Elf64_Sym
 #define ARCH_ELFCLASS ELFCLASS64
-#elif (__WORDSIZE == 32)
+#else
 #define ehdr_t Elf32_Ehdr
 #define shdr_t Elf32_Shdr
 #define dyn_t Elf32_Dyn
 #define sym_t Elf32_Sym
 #define ARCH_ELFCLASS ELFCLASS32
-#else
-static_assert(false, "unknown build environment");
 #endif
 
 namespace pyflame {

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -334,7 +334,7 @@ def test_trace(force_abi, trace_threads):
         args.extend(['--abi', abi_string])
     if trace_threads:
         args.append('--threads')
-    args.extend(['-t', python_command(), 'tests/exit_early.py', '-s'])
+    args.extend(['-t', sys.executable, 'tests/exit_early.py', '-s'])
 
     proc = subprocess.Popen(
         args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -36,6 +36,13 @@ MISSING_THREADS = not (platform.architecture()[0] == '64bit' and
                        platform.machine in ('i386', 'x86_64'))
 
 
+def test_build_environment():
+    if os.environ.get('ARCH') == 'i386':
+        assert platform.architecture()[0] == '32bit'
+    elif os.environ.get('ARCH') == 'amd64':
+        assert platform.architecture()[0] == '64bit'
+
+
 @contextlib.contextmanager
 def proc(argv, wait_for_pid=True):
     # start the process and wait for it to print its pid... we explicitly do

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -52,7 +52,7 @@ def proc(argv, wait_for_pid=True):
 
 
 def python_command():
-    return 'python%d' % (sys.version_info[0], )
+    return 'python%d.%d' % sys.version_info[0:2]
 
 
 def python_proc(test_file):

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -51,6 +51,10 @@ def proc(argv, wait_for_pid=True):
         proc.kill()
 
 
+def guess_python_cmd():
+    return 'python%d.%d' % sys.version_info[:2]
+
+
 def python_proc(test_file):
     return proc([sys.executable, './tests/%s' % (test_file, )])
 
@@ -334,7 +338,7 @@ def test_trace(force_abi, trace_threads):
         args.extend(['--abi', abi_string])
     if trace_threads:
         args.append('--threads')
-    args.extend(['-t', sys.executable, 'tests/exit_early.py', '-s'])
+    args.extend(['-t', guess_python_cmd(), 'tests/exit_early.py', '-s'])
 
     proc = subprocess.Popen(
         args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -51,10 +51,6 @@ def proc(argv, wait_for_pid=True):
         proc.kill()
 
 
-def guess_python_cmd():
-    return 'python%d.%d' % sys.version_info[:2]
-
-
 def python_proc(test_file):
     return proc([sys.executable, './tests/%s' % (test_file, )])
 
@@ -338,7 +334,7 @@ def test_trace(force_abi, trace_threads):
         args.extend(['--abi', abi_string])
     if trace_threads:
         args.append('--threads')
-    args.extend(['-t', guess_python_cmd(), 'tests/exit_early.py', '-s'])
+    args.extend(['-t', sys.executable, 'tests/exit_early.py', '-s'])
 
     proc = subprocess.Popen(
         args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import contextlib
+import os
 import platform
 import pytest
 import re
@@ -36,11 +37,19 @@ MISSING_THREADS = not (platform.architecture()[0] == '64bit' and
                        platform.machine in ('i386', 'x86_64'))
 
 
-def test_build_environment():
-    if os.environ.get('ARCH') == 'i386':
+@pytest.mark.skipif(
+    os.environ.get('TRAVIS') != 'true',
+    reason='Sanity check is only run on Travis.')
+def test_travis_build_environment():
+    """Sanity checks of the Travis test environment itself."""
+    arch = os.environ['ARCH']
+    if arch == 'i386':
         assert platform.architecture()[0] == '32bit'
-    elif os.environ.get('ARCH') == 'amd64':
+    elif arch == 'amd64':
         assert platform.architecture()[0] == '64bit'
+    else:
+        assert False, 'Unknown ARCH'
+    assert 'python%d.%d' % sys.version_info[:2] == os.environ['PYVERSION']
 
 
 @contextlib.contextmanager

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -51,12 +51,8 @@ def proc(argv, wait_for_pid=True):
         proc.kill()
 
 
-def python_command():
-    return 'python%d.%d' % sys.version_info[0:2]
-
-
 def python_proc(test_file):
-    return proc([python_command(), './tests/%s' % (test_file, )])
+    return proc([sys.executable, './tests/%s' % (test_file, )])
 
 
 @pytest.yield_fixture

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -219,9 +219,9 @@ def test_legacy_pid_handling(threaded_busy):
         stderr=subprocess.PIPE,
         universal_newlines=True)
     out, err = communicate(proc)
+    assert err.startswith('WARNING: ')
     assert proc.returncode == 0
     lines = out.strip().split('\n')
-    assert err.startswith('WARNING: ')
     assert len(lines) == 1
 
 

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -133,7 +133,7 @@ def test_monitor(dijkstra):
         stderr=subprocess.PIPE,
         universal_newlines=True)
     out, err = communicate(proc)
-    assert not err
+    assert not err, sys.executable
     assert proc.returncode == 0
     lines = out.split('\n')
     assert lines.pop(-1) == ''  # output should end in a newline


### PR DESCRIPTION
This fixes a few minor problems with building/running Pyflame on 32-bit x86 hosts (what Debian calls i386, and what autotools calls i686). Most of these fixes are either just updates to the test suite, and a couple of obscure fixes for profiling 32-bit Python builds from 64-bit hotss.