### PR TITLE
disable i386 python 2.7 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 sudo: required
 dist: trusty
 language: cpp
-compiler:
-  - gcc
-  - clang
+compiler: gcc
 
 # This is kind of hacky, so it deserves an explanation.
 #
@@ -28,7 +26,7 @@ env:
     - MAKEOPTS=-j3
   matrix:
     - ARCH=i386 PYVERSION=python2.6 PY26_CFLAGS=-I/usr/include/python2.6 PY26_LIBS=-lpython2.6
-    - ARCH=i386 PYVERSION=python2.7 PY26_CFLAGS=-I/usr/include/python2.7 PY26_LIBS=-lpython2.7
+    #- ARCH=i386 PYVERSION=python2.7 PY26_CFLAGS=-I/usr/include/python2.7 PY26_LIBS=-lpython2.7   # currently broken due to travis horkage
     - ARCH=i386 PYVERSION=python3.4
     - ARCH=i386 PYVERSION=python3.5
     - ARCH=i386 PYVERSION=python3.6


### PR DESCRIPTION
I spent several hours looking at this today, and the build environment is all messed up on this host. Some notes on what I saw:
 * `PATH` is set up in this terribly broken way so that you get a `virtualenv` from `/usr/local/bin` that is hard coded to use `/usr/bin/python`
 * When trying to force everything to the right version, I still get ABI errors indicating the 32-bit python buidl is launching the 64-bit python
I don't know why this randomly broke overnight (well I do -- Travis must have updated their Docker images). It would be great to fix this for real sometime.