### PR TITLE
show supported ABIs in -v output

### DIFF
--- a/src/prober.cc
+++ b/src/prober.cc
@@ -64,6 +64,30 @@ static const char usage_str[] =
      "  --flamechart         Include timestamps for generating Chrome "
      "\"flamecharts\"\n");
 
+// The ABIs supported in this Pyflame build.
+static const int build_abis[] = {
+#ifdef ENABLE_PY26
+    26,
+#endif
+#ifdef ENABLE_PY34
+    34,
+#endif
+#ifdef ENABLE_PY36
+    36,
+#endif
+};
+
+static_assert(sizeof(build_abis) > 0, "No Python ABIs detected!");
+
+static inline void ShowVersion(std::ostream &out) {
+  const size_t sz = sizeof(build_abis) / sizeof(int);
+  out << PYFLAME_VERSION_STR << " (ABI list: ";
+  for (size_t i = 0; i < sz - 1; i++) {
+    out << build_abis[i] << " ";
+  }
+  out << build_abis[sz - 1] << ")\n";
+}
+
 static inline std::chrono::microseconds ToMicroseconds(double val) {
   return std::chrono::microseconds{static_cast<long>(val * 1000000)};
 }
@@ -210,7 +234,7 @@ int Prober::ParseOpts(int argc, char **argv) {
         include_ts_ = true;
         break;
       case 'v':
-        std::cout << PYFLAME_VERSION_STR << "\n";
+        ShowVersion(std::cout);
         return 0;
         break;
       case 'x':

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -514,7 +514,7 @@ def test_version(flag):
     assert proc.returncode == 0
 
     version_re = re.compile(
-        r'^Pyflame \d+\.\d+\.\d+ \(commit [\w]+\) \S+ \S+$')
+        r'^Pyflame \d+\.\d+\.\d+ \(commit [\w]+\) \S+ \S+ \(ABI list: .+\)$')
     assert version_re.match(out.strip())
 
 


### PR DESCRIPTION
Output looks like this:

```
$ ./src/pyflame -v
Pyflame 1.5.5 (commit d1942a5) linux-gnu x86_64 (ABI list: 26 36)
```