### PR TITLE
Partial fix for #122

### DIFF
--- a/src/ptrace.cc
+++ b/src/ptrace.cc
@@ -49,8 +49,8 @@ int DoWait(pid_t pid, int options) {
       if (signum == SIGTRAP) {
         break;
       } else if (signum == SIGCHLD) {
-        ss << "Received SIGCHLD from PID " << pid;
-        throw TerminateException(ss.str());
+        PtraceCont(pid);  // see issue #122
+        continue;
       }
       ss << "waitpid() indicated a WIFSTOPPED process, but got unexpected "
             "signal "

--- a/tests/sleeper.py
+++ b/tests/sleeper.py
@@ -12,19 +12,37 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import argparse
 import os
 import sys
 import time
 
 
 def main():
-    sys.stdout.write('%d\n' % (os.getpid(), ))
-    sys.stdout.flush()
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-t', '--time', default=0, type=int, help='How long to run for')
+    parser.add_argument(
+        '-f', '--fork', action='store_true', help='Fork child processes')
+    args = parser.parse_args()
+
+    if not args.fork:
+        sys.stdout.write('%d\n' % (os.getpid(), ))
+        sys.stdout.flush()
+    t0 = time.time()
     while True:
         time.sleep(0.1)
         target = time.time() + 0.1
         while time.time() < target:
             pass
+        if args.fork:
+            pid = os.fork()
+            if pid == 0:
+                sys.exit(0)
+            else:
+                os.waitpid(pid, 0)
+        if args.time and time.time() - t0 >= args.time:
+            break
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This seems to improve the issue reported by #122 but it is not a complete fix. When I add the `from numba import jit` line to the test script, I still get an error like:

```
E       AssertionError: assert not 'Unexpected ptrace(2) exception: waitpid() indicated a WIFSTOPPED process, but got unexpected signal 6\n'
```

Signal 6 is SIGABRT. For some reason this doesn't happen when I run by hand.