### PR TITLE
Detect errors with pkg-tools macro expansion

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5,6 +5,9 @@ AC_CONFIG_HEADERS([src/config.h])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_SRCDIR([src/pyflame.cc])
 
+# Detect errors with pkg-tools macro expansion
+m4_pattern_forbid([^PKG_])
+
 # Fail early if the user tries to build for BSD/OS X
 AC_CANONICAL_HOST
 AS_CASE([$host_os],


### PR DESCRIPTION
In case of autotools misconfiguration, the pkg.m4 macro file might not
be found. With this patch applied, autotools will warn about unexpanded
macros from pkg-tool.

Otherwise autotools will only warn about the unexpanded `AC_MSG_WARN` macros within the `PKG` macros which is not too helpful.

Documentation: https://www.gnu.org/software/autoconf/manual/autoconf-2.62/html_node/Forbidden-Patterns.html