### PR TITLE
Add a flag to disable line numbers

### DIFF
--- a/src/frame.cc
+++ b/src/frame.cc
@@ -19,4 +19,12 @@ std::ostream &operator<<(std::ostream &os, const Frame &frame) {
   os << frame.file() << ':' << frame.name() << ':' << frame.line();
   return os;
 }
+
+void print_frame(std::ostream &os, const Frame &frame) {
+  os << frame.file() << ':' << frame.name() << ':' << frame.line();
+}
+
+void print_frame_without_line_number(std::ostream &os, const Frame &frame) {
+  os << frame.file() << ':' << frame.name();
+}
 }  // namespace pyflame

--- a/src/frame.h
+++ b/src/frame.h
@@ -49,7 +49,10 @@ class Frame {
 };
 
 std::ostream &operator<<(std::ostream &os, const Frame &frame);
+void print_frame(std::ostream &os, const Frame &frame);
+void print_frame_without_line_number(std::ostream &os, const Frame &frame);
 
+typedef void (*print_frame_t) (std::ostream &, const Frame &);
 typedef std::vector<Frame> frames_t;
 
 struct FrameHash {

--- a/src/prober.cc
+++ b/src/prober.cc
@@ -47,25 +47,25 @@ static const char usage_str[] =
      "\n"
      "Common Options:\n"
 #ifdef ENABLE_THREADS
-     "  --threads            Enable multi-threading support\n"
-     "  -d, --dump           Dump stacks from all threads (implies --threads)\n"
+     "  --threads                Enable multi-threading support\n"
+     "  -d, --dump               Dump stacks from all threads (implies --threads)\n"
 #else
-     "  -d, --dump           Dump the current interpreter stack\n"
+     "  -d, --dump               Dump the current interpreter stack\n"
 #endif
-     "  -h, --help           Show help\n"
-     "  -o, --output=PATH    Output to file path\n"
-     "  -p, --pid=PID        The PID to trace\n"
-     "  -r, --rate=RATE      Sample rate, as a fractional value of seconds "
+     "  -h, --help               Show help\n"
+     "  -o, --output=PATH        Output to file path\n"
+     "  -p, --pid=PID            The PID to trace\n"
+     "  -r, --rate=RATE          Sample rate, as a fractional value of seconds "
      "(default 0.01)\n"
-     "  -s, --seconds=SECS   How many seconds to run for (default 1)\n"
-     "  -t, --trace          Trace a child process\n"
-     "  -v, --version        Show the version\n"
-     "  -x, --exclude-idle   Exclude idle time from statistics\n"
-     "  --no-line-numbers    Do not append line numbers to function names\n"
+     "  -s, --seconds=SECS       How many seconds to run for (default 1)\n"
+     "  -t, --trace              Trace a child process\n"
+     "  -v, --version            Show the version\n"
+     "  -x, --exclude-idle       Exclude idle time from statistics\n"
+     "  -n, --no-line-numbers    Do not append line numbers to function names\n"
      "\n"
      "Advanced Options:\n"
-     "  --abi                Force a particular Python ABI (26, 34, 36)\n"
-     "  --flamechart         Include timestamps for generating Chrome "
+     "  --abi                    Force a particular Python ABI (26, 34, 36)\n"
+     "  --flamechart             Include timestamps for generating Chrome "
      "\"flamecharts\"\n");
 
 // The ABIs supported in this Pyflame build.
@@ -179,7 +179,7 @@ static void PrintFramesTS(std::ostream &out,
 }
 
 int Prober::ParseOpts(int argc, char **argv) {
-  static const char short_opts[] = "dho:p:r:s:tvx";
+  static const char short_opts[] = "dho:p:r:s:tvxn";
   static struct option long_opts[] = {
     {"abi", required_argument, 0, 'a'},
     {"dump", no_argument, 0, 'd'},
@@ -195,7 +195,7 @@ int Prober::ParseOpts(int argc, char **argv) {
     {"flamechart", no_argument, 0, 'T'},
     {"version", no_argument, 0, 'v'},
     {"exclude-idle", no_argument, 0, 'x'},
-    {"no-line-numbers", no_argument, 0, 'N'},
+    {"no-line-numbers", no_argument, 0, 'n'},
     {0, 0, 0, 0}
   };
 
@@ -271,7 +271,7 @@ int Prober::ParseOpts(int argc, char **argv) {
       case 'o':
         output_file_ = optarg;
         break;
-      case 'N':
+      case 'n':
         include_line_number_ = false;
         break;
       case '?':

--- a/src/prober.h
+++ b/src/prober.h
@@ -37,6 +37,7 @@ class Prober {
         trace_(false),
         include_idle_(true),
         include_ts_(false),
+        include_line_number_(true),
         enable_threads_(false),
         seconds_(1),
         sample_rate_(0.01) {}
@@ -60,6 +61,7 @@ class Prober {
   bool trace_;
   bool include_idle_;
   bool include_ts_;
+  bool include_line_number_;
   bool enable_threads_;
   double seconds_;
   double sample_rate_;

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -36,6 +36,10 @@ SLEEP_B_RE = re.compile(r'.*:sleep_b:.*')
 
 MISSING_THREADS = platform.machine() != 'x86_64'
 
+IS_DOCKER = False
+""" Returns: True if running in a Docker container, else False """
+with open('/proc/1/cgroup', 'rt') as ifh:
+    IS_DOCKER = 'docker' in ifh.read()
 
 @pytest.mark.skipif(
     os.environ.get('TRAVIS') != 'true',
@@ -463,6 +467,9 @@ def test_sample_extra_args():
     assert proc.returncode == 1
 
 
+@pytest.mark.skipif(
+    IS_DOCKER,
+    reason='There is not init process in Docker')
 def test_permission_error():
     # we should not be allowed to trace init
     proc = subprocess.Popen(

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -24,8 +24,10 @@ import sys
 import time
 
 IDLE_RE = re.compile(r'^\(idle\) \d+$')
-FLAMEGRAPH_RE = re.compile(r'^((?:[^:]+:[^:]+:\d+)(?:;[^:]+:[^:]+:\d+)*) (\d+)$')
-FLAMEGRAPH_NONUMBER_RE = re.compile(r'^((?:[^:]+:[^:]+)(?:;[^:]+:[^:]+)*) (\d+)$')
+FLAMEGRAPH_RE = re.compile(
+    r'^((?:[^:]+:[^:]+:\d+)(?:;[^:]+:[^:]+:\d+)*) (\d+)$')
+FLAMEGRAPH_NONUMBER_RE = re.compile(
+    r'^((?:[^:]+:[^:]+)(?:;[^:]+:[^:]+)*) (\d+)$')
 TS_IDLE_RE = re.compile(r'\(idle\)')
 # Matches strings of the form
 # './tests/sleeper.py:<module>:31;./tests/sleeper.py:main:26;'
@@ -45,6 +47,7 @@ try:
 except:
     # Ignore exception, since there's nothing we can do
     pass
+
 
 @pytest.mark.skipif(
     os.environ.get('TRAVIS') != 'true',
@@ -479,9 +482,7 @@ def test_sample_extra_args():
     assert proc.returncode == 1
 
 
-@pytest.mark.skipif(
-    IS_DOCKER,
-    reason='There is not init process in Docker')
+@pytest.mark.skipif(IS_DOCKER, reason='There is not init process in Docker')
 def test_permission_error():
     # we should not be allowed to trace init
     proc = subprocess.Popen(
@@ -616,6 +617,7 @@ def test_thread_dump(threaded_dijkstra):
             threads += 1
     assert threads == 5
 
+
 def test_no_line_numbers(dijkstra):
     """Basic test for --no-line-numbers"""
     proc = subprocess.Popen(
@@ -633,4 +635,5 @@ def test_no_line_numbers(dijkstra):
     # With no line numbers included there can be duplicate lines,
     # but flamegraph.pl performs deduplication as well
     for line in lines:
-        assert_flamegraph(line, allow_idle=True, line_re=FLAMEGRAPH_NONUMBER_RE)
+        assert_flamegraph(
+            line, allow_idle=True, line_re=FLAMEGRAPH_NONUMBER_RE)

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -38,9 +38,13 @@ SLEEP_B_RE = re.compile(r'.*:sleep_b:.*')
 MISSING_THREADS = platform.machine() != 'x86_64'
 
 IS_DOCKER = False
-""" Returns: True if running in a Docker container, else False """
-with open('/proc/1/cgroup', 'rt') as ifh:
-    IS_DOCKER = 'docker' in ifh.read()
+try:
+    """ Returns: True if running in a Docker container, else False """
+    with open('/proc/1/cgroup', 'rt') as ifh:
+        IS_DOCKER = 'docker' in ifh.read()
+except:
+    # Ignore exception, since there's nothing we can do
+    pass
 
 @pytest.mark.skipif(
     os.environ.get('TRAVIS') != 'true',


### PR DESCRIPTION
### Summary
This PR adds a new command line parameter `--no-line-numbers` which allows to disable output of line numbers in the resulting call stack traces.

### Motivation
I use this library from time to time to profile our python applications and very often I don't require up to a line number level of detail. Most of the time I'm interested to know how long it took the method to execute. Right now, with line numbers enabled, a single method may be split into multiple parts which make it a bit inconvenient. If problem is introduced by one of the downstream methods I can always figure out the line number by looking at the source code.

### Changes
* A new command line parameter `--no-line-numbers` has been added
* Added two new functions which replace `<<` operator to print frame: `print_frame` and `print_frame_without_line_number`
* Skip `test_permission_error` test when executed in Docker environment, since there's no `init` process which is protected from profiling
* Improve regular expression used to validate and extract call stack from the output
* Unit test for new command line parameter 

### Known Issues
With this change the output may contain duplicate call stacks since the code uses file name + line number tuple as a key to perform deduplication. I didn't want this code to be too invasive so I didn't fix that, but `flamegraph.pl` performs deduplication of it's own, so it's not really a major issue, unless other tools to generate flamegraph are used which do not deduplicate.

I can tackle if you think it's worth it.

