### PR TITLE
Some small fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -92,7 +92,7 @@ AC_CHECK_FUNCS([getpagesize memmove munmap strerror strtol strtoul])
 
 AC_DEFINE_UNQUOTED(
   [PYFLAME_VERSION_STR],
-  ["Pyflame $PACKAGE_VERSION $host_os $host_cpu"],
+  ["pyflame $PACKAGE_VERSION $host_os $host_cpu"],
   [A string containing build information.])
 
 enable_py26=no

--- a/runtests.sh
+++ b/runtests.sh
@@ -48,15 +48,23 @@ pytest() {
   fi
 }
 
+mkvenv() {
+  if exists virtualenv-3; then
+    virtualenv-3 "$@"
+  elif exists virtualenv; then
+    virtualenv "$@"
+  else
+    echo "failed to find virtualenv command"
+    exit 1
+  fi
+}
+
 # Run tests using pip; $1 = python version
 run_pip_tests() {
   local activated
   if [ -z "${VIRTUAL_ENV}" ]; then
     rm -rf "${ENVDIR}"
-    if ! virtualenv -q -p "$1" "${ENVDIR}" &>/dev/null; then
-      echo "Error: failed to create virtualenv"
-      return 1
-    fi
+    mkvenv -q -p "$1" "${ENVDIR}" &>/dev/null
 
     # shellcheck source=/dev/null
     . "${ENVDIR}/bin/activate"

--- a/src/prober.cc
+++ b/src/prober.cc
@@ -42,7 +42,7 @@
 
 // Microseconds in a second.
 static const char usage_str[] =
-    ("Usage: pyflame [options] -p PID\n"
+    ("Usage: pyflame [options] [-p] PID\n"
      "       pyflame [options] -t command arg1 arg2...\n"
      "\n"
      "Common Options:\n"
@@ -115,7 +115,7 @@ static void PrintFrames(std::ostream &out,
     out << "(idle) " << idle_count << "\n";
   }
   if (failed_count) {
-    out << "(failed) "  << failed_count << "\n";
+    out << "(failed) " << failed_count << "\n";
   }
   // Put the call stacks into buckets
   buckets_t buckets;
@@ -155,7 +155,8 @@ static void PrintFramesTS(std::ostream &out,
       out << "(idle)\n";
       continue;
     }
-    if (call_stack.frames.size() == 1 && call_stack.frames.front().file() == "(failed)") {
+    if (call_stack.frames.size() == 1 &&
+        call_stack.frames.front().file() == "(failed)") {
       out << "(failed)\n";
       continue;
     }
@@ -480,7 +481,7 @@ int Prober::FindSymbols(PyFrob *frobber) {
 pid_t Prober::ParsePid(const char *pid_str) {
   long pid = std::strtol(pid_str, nullptr, 10);
   if (pid <= 0 || pid > std::numeric_limits<pid_t>::max()) {
-    std::cerr << "PID " << pid << " is out of valid PID range.\n";
+    std::cerr << "Error: failed to parse \"" << pid_str << "\" as a PID.\n\n";
     return -1;
   }
   return static_cast<pid_t>(pid);

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -484,7 +484,7 @@ def test_invalid_pid(pid):
         stderr=subprocess.PIPE)
     out, err = communicate(proc)
     assert not out
-    assert err.startswith('Failed to seize PID ') or 'valid PID range' in err
+    assert err.startswith('Failed to seize PID ') or 'failed to parse' in err
     assert proc.returncode == 1
 
 

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -537,7 +537,7 @@ def test_version(flag):
     assert proc.returncode == 0
 
     version_re = re.compile(
-        r'^Pyflame \d+\.\d+\.\d+ (\(commit [\w]+\) )?\S+ \S+ \(ABI list: .+\)$'
+        r'^pyflame \d+\.\d+\.\d+ (\(commit [\w]+\) )?\S+ \S+ \(ABI list: .+\)$'
     )
     assert version_re.match(out.strip())
 


### PR DESCRIPTION
This fixes a few things:
 * Fix `make check` when `virtualenv` is named `virtualenv-3`
 * Better error message when pyflame is run with a non-pid argument
 * Use lowercase command name in `-v` output