### PR TITLE
Use new ppa for installing Python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
 addons:
   apt:
     sources:
-      - sourceline: 'ppa:fkrull/deadsnakes'
+      - sourceline: 'ppa:deadsnakes/ppa'
       - autotools-dev
       - libtool
       - pkg-config


### PR DESCRIPTION
As a first step to Python 3.7 support, I've updated the PPA used to install Python from.

[ppa:fkrull/deadsnakes says](https://launchpad.net/~fkrull/+archive/ubuntu/deadsnakes):
> This repository is kept for historical purposes, but NOT UPDATED. Please use the new repository at
>
> https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa
>
> instead!