### PR TITLE
Improve PtraceSeize error output 

### DIFF
--- a/src/prober.cc
+++ b/src/prober.cc
@@ -365,7 +365,7 @@ int Prober::InitiatePtrace(char **argv) {
     try {
       PtraceSeize(pid_);
     } catch (const PtraceException &err) {
-      std::cerr << "Failed to seize PID " << pid_ << "\n";
+      std::cerr << err.what() << "\n";
       return 1;
     }
   }

--- a/src/ptrace.cc
+++ b/src/ptrace.cc
@@ -97,7 +97,7 @@ void PtraceAttach(pid_t pid) {
 void PtraceSeize(pid_t pid) {
   if (ptrace(PTRACE_SEIZE, pid, 0, 0)) {
     std::ostringstream ss;
-    ss << "Failed to attach to PID " << pid << ": " << strerror(errno);
+    ss << "Failed to seize PID " << pid << ": " << strerror(errno);
     throw PtraceException(ss.str());
   }
 }


### PR DESCRIPTION
I think it is useful to see the exact error that is returned by ptrace when we try to profile the process.