### PR TITLE
[BUGFIX] Find the correct segment on Debian Unstable

### DIFF
--- a/src/symbol.cc
+++ b/src/symbol.cc
@@ -169,7 +169,7 @@ PyABI ELF::WalkTable(int sym, int str, PyAddresses *addrs) {
 addr_t ELF::GetBaseAddress() {
   int32_t phnum = hdr()->e_phnum;
   int32_t i;
-  for (i = 0; i < phnum && phdr(i)->p_type != PT_LOAD; i++) {
+  for (i = 0; i < phnum && (phdr(i)->p_type != PT_LOAD || (phdr(i)->p_flags & PF_X) == 0); i++) {
   }
   if (i == phnum) {
     throw FatalException("Failed to find PT_LOAD entry in program headers");


### PR DESCRIPTION
Since binutils 2.31, the options --enable-separate-code is enabled by default for Linux x86 binaries.
(see changelog https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;a=blob_plain;f=ld/NEWS;hb=refs/tags/binutils-2_31)
This new version of binutils is the version of last Debian Unstable.

You can still compile your binaries with the option "-z no-separate-code" in gcc, but pyflame should be able to support this.

This breaks pyflame, in the parsing of the ELF, in the function GetBaseAddress : we're looking for the start of the .text section,  but because of this change into binutils, the first PT_LOAD segment found is the ELF header segment, and not the .text.

The patch now look for a PT_LOAD segment with the executable flags, since the ELF header segment is not executable.

I already found a bug with the same root cause in frida and patched it:  https://github.com/frida/frida-core/pull/208 

Tested on python 2.7.15 and 3.6.7.

Thanks for the project, and don't use Debian Unstable !

