### PR TITLE
Fixed overflow in ELF::NededLibs and ELF::WalkTable

### DIFF
--- a/src/symbol.cc
+++ b/src/symbol.cc
@@ -111,7 +111,7 @@ std::vector<std::string> ELF::NeededLibs() {
   std::vector<std::string> needed;
   const shdr_t *s = shdr(dynamic_);
   const shdr_t *d = shdr(dynstr_);
-  for (uint16_t i = 0; i < s->sh_size / s->sh_entsize; i++) {
+  for (word_t i = 0; i < s->sh_size / s->sh_entsize; i++) {
     const dyn_t *dyn =
         reinterpret_cast<const dyn_t *>(p() + s->sh_offset + i * s->sh_entsize);
     if (dyn->d_tag == DT_NEEDED) {
@@ -127,7 +127,7 @@ PyABI ELF::WalkTable(int sym, int str, PyAddresses *addrs) {
   bool have_abi = false;
   const shdr_t *s = shdr(sym);
   const shdr_t *d = shdr(str);
-  for (uint16_t i = 0; i < s->sh_size / s->sh_entsize; i++) {
+  for (word_t i = 0; i < s->sh_size / s->sh_entsize; i++) {
     if (have_abi && addrs->tstate_addr && addrs->interp_head_addr &&
         addrs->interp_head_fn_addr) {
       break;

--- a/src/symbol.h
+++ b/src/symbol.h
@@ -33,6 +33,7 @@
 #define dyn_t Elf64_Dyn
 #define sym_t Elf64_Sym
 #define addr_t Elf64_Addr
+#define word_t Elf64_Word
 #define ARCH_ELFCLASS ELFCLASS64
 #else
 #define ehdr_t Elf32_Ehdr
@@ -41,6 +42,7 @@
 #define dyn_t Elf32_Dyn
 #define sym_t Elf32_Sym
 #define addr_t Elf32_Addr
+#define word_t Elf32_Word
 #define ARCH_ELFCLASS ELFCLASS32
 #endif
 


### PR DESCRIPTION
Embedded CPython builds could have more than 2**16 symbols. This
commit changes the iteration counter type in the aforementioned
methods to Elf*Word.