### PR TITLE
Minor improvements of the usage help provided by the --help option

### DIFF
--- a/src/prober.cc
+++ b/src/prober.cc
@@ -47,7 +47,7 @@ static const char usage_str[] =
      "\n"
      "Common Options:\n"
 #ifdef ENABLE_THREADS
-     "  --threads                Enable multi-threading support\n"
+     "  -L, --threads            Enable multi-threading support\n"
      "  -d, --dump               Dump stacks from all threads (implies "
      "--threads) and exit\n"
 #else

--- a/src/prober.cc
+++ b/src/prober.cc
@@ -48,9 +48,10 @@ static const char usage_str[] =
      "Common Options:\n"
 #ifdef ENABLE_THREADS
      "  --threads                Enable multi-threading support\n"
-     "  -d, --dump               Dump stacks from all threads (implies --threads)\n"
+     "  -d, --dump               Dump stacks from all threads (implies "
+     "--threads) and exit\n"
 #else
-     "  -d, --dump               Dump the current interpreter stack\n"
+     "  -d, --dump               Dump the current interpreter stack and exit\n"
 #endif
      "  -h, --help               Show help\n"
      "  -n, --no-line-numbers    Do not append line numbers to function names\n"


### PR DESCRIPTION
Document two things that were not obvious (to me):
- the short option for `--threads` is `-L`
- `--dump` performs a single dump of call stacks and **exits**.