### PR TITLE
Switch to the deadsnakes PPA

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
 addons:
   apt:
     sources:
-      - sourceline: 'ppa:fkrull/deadsnakes'
+      - sourceline: 'ppa:deadsnakes/ppa'
       - autotools-dev
       - libtool
       - pkg-config


### PR DESCRIPTION
The PPA from fkrull does not contain the latest python
version (currently 3.7) so switch to the deadsnakes PPA[1] which has
all needed versions.

[1] https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa