### PR TITLE
Fix pyflame for code compiled with ld -z separate-code

### DIFF
--- a/NEWS.org
+++ b/NEWS.org
@@ -1,4 +1,7 @@
 * NEWS (user visible changes)
+** 1.6.7 (2018-06-25)
+   - Improved support for prelinked binaries, especially on ARM32 and Yocto
+     systems. (Andrew Jeffery)
 
 **  1.6.6 (2018-05-02)
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.68])
-AC_INIT([pyflame], [1.6.6], [evan@eklitzke.org])
+AC_INIT([pyflame], [1.6.7], [evan@eklitzke.org])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_HEADERS([src/config.h])
 AC_CONFIG_MACRO_DIR([m4])

--- a/src/aslr.cc
+++ b/src/aslr.cc
@@ -28,8 +28,7 @@ size_t LocateLibPython(pid_t pid, const std::string &hint, std::string *path) {
   std::string line;
   std::string elf_path;
   while (std::getline(fp, line)) {
-    if (line.find(hint) != std::string::npos &&
-        line.find(" r-xp ") != std::string::npos) {
+    if (line.find(hint) != std::string::npos) {
       size_t pos = line.find('/');
       if (pos == std::string::npos) {
         throw FatalException("Did not find libpython absolute path");


### PR DESCRIPTION
This generates VAS layouts like this:

<pre>
555555554000-5555555a8000 r--p 00000000 08:02 919707                     /opt/python-3.6.8/bin/python3.6
5555555a8000-55555573d000 r-xp 00054000 08:02 919707                     /opt/python-3.6.8/bin/python3.6
55555573d000-5555557ce000 r--p 001e9000 08:02 919707                     /opt/python-3.6.8/bin/python3.6
5555557cf000-555555835000 rw-p 0027a000 08:02 919707                     /opt/python-3.6.8/bin/python3.6
555555835000-555555865000 rw-p 00000000 00:00 0                          [heap]
7ffff7fd0000-7ffff7fd3000 r--p 00000000 00:00 0                          [vvar]
7ffff7fd3000-7ffff7fd5000 r-xp 00000000 00:00 0                          [vdso]
7ffff7fd5000-7ffff7fd6000 r--p 00000000 08:02 265255                     /lib/x86_64-linux-gnu/ld-2.28.so
7ffff7fd6000-7ffff7ff4000 r-xp 00001000 08:02 265255                     /lib/x86_64-linux-gnu/ld-2.28.so
7ffff7ff4000-7ffff7ffc000 r--p 0001f000 08:02 265255                     /lib/x86_64-linux-gnu/ld-2.28.so
7ffff7ffc000-7ffff7ffe000 rw-p 00026000 08:02 265255                     /lib/x86_64-linux-gnu/ld-2.28.so
7ffff7ffe000-7ffff7fff000 rw-p 00000000 00:00 0
7ffffffde000-7ffffffff000 rw-p 00000000 00:00 0                          [stack]
</pre>

This is enabled by default on Linux/x86 since 2.29
(f6aec96dce1ddbd8961a3aa8a2925db2021719bb).