### PR TITLE
Add dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM ubuntu:16.04
+
+RUN apt-get -y update && \
+    apt-get install -yqq --no-install-recommends \
+	software-properties-common autoconf automake autotools-dev g++ pkg-config libtool make && \
+    apt-get clean
+
+
+RUN add-apt-repository ppa:deadsnakes/ppa
+RUN apt-get -y update && \
+    apt-get install -yqq --no-install-recommends \
+    python2.7-dev python3.5-dev python3.6-dev python3.7-dev && \
+    apt-get clean
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,6 @@ RUN apt-get -y update && \
 RUN add-apt-repository ppa:deadsnakes/ppa
 RUN apt-get -y update && \
     apt-get install -yqq --no-install-recommends \
-    python2.7-dev python3.5-dev python3.6-dev python3.7-dev && \
+    python2.7-dev python3.5-dev python3.6-dev && \
     apt-get clean
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The `make` command will produce an executable at `src/pyflame` that you can run
 and use.
 
 Or you can use docker to build pyflame
-```base```
+```bash
 sudo docker build --tag pyflame .
 sudo docker run -it -v $(pwd):/root/pyflame pyflame /bin/bash -c "cd /root/pyflame;./autogen.sh;./configure;make"
 ```

--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ make
 The `make` command will produce an executable at `src/pyflame` that you can run
 and use.
 
+Or you can use docker to build pyflame
+```base```
+sudo docker build --tag pyflame .
+sudo docker run -it -v $(pwd):/root/pyflame pyflame /bin/bash -c "cd /root/pyflame;./autogen.sh;./configure;make"
+```
+This will also produce the executable at `src/pyflame`, which support py2.6/2.7/3.4/3.5/3.6/3.7
+
 Optionally, if you have `virtualenv` installed, you can test the executable you
 produced using `make check`.
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Or you can use docker to build pyflame
 sudo docker build --tag pyflame .
 sudo docker run -it -v $(pwd):/root/pyflame pyflame /bin/bash -c "cd /root/pyflame;./autogen.sh;./configure;make"
 ```
-This will also produce the executable at `src/pyflame`, which support py2.6/2.7/3.4/3.5/3.6/3.7
+This will also produce the executable at `src/pyflame`, which support py2.6/2.7/3.4/3.5/3.6
 
 Optionally, if you have `virtualenv` installed, you can test the executable you
 produced using `make check`.


### PR DESCRIPTION
You can use docker to build pyflame
```bash
sudo docker build --tag pyflame .
sudo docker run -it -v $(pwd):/root/pyflame pyflame /bin/bash -c "cd /root/pyflame;./autogen.sh;./configure;make"
```
This will also produce the executable at `src/pyflame`, which support py2.6/2.7/3.4/3.5/3.6
